### PR TITLE
Switch to official project accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,5 @@
 
 The latest development version of yt could be downloaded from our custom anaconda channel:
 ```
-# conda install -c yt-project/label/dev yt
-# Use my personal account before the official one is set up
-conda install -c qobilidop/label/dev yt
+conda install -c yt-project/label/dev yt
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Conda recipes for nightly builds of yt packages
+[![Build Status](https://travis-ci.org/yt-project/conda-dev.svg?branch=master)](https://travis-ci.org/yt-project/conda-dev)
+[![Build status](https://ci.appveyor.com/api/projects/status/3plsrf8wvnc87vi9/branch/master?svg=true)](https://ci.appveyor.com/project/qobilidop/conda-dev/branch/master)
 
 The latest development version of yt could be downloaded from our custom anaconda channel:
 ```

--- a/build.py
+++ b/build.py
@@ -79,13 +79,20 @@ def conda_build(recipe_dir, py_ver):
     return pkg_file
 
 
+def check_env(name, value):
+    if (name in os.environ) and (os.environ[name] == value):
+        return True
+    else:
+        return False
+
+
 def anaconda_upload(pkg_file, user):
     # Don't upload when not using CI
     # This check works for most CIs including Travis CI and AppVeyor
     if not 'CI' in os.environ:
         return
     # Don't upload from pull requests
-    if os.environ['TRAVIS_EVENT_TYPE'] == 'pull_request':
+    if check_env('TRAVIS_EVENT_TYPE', 'pull_request'):
         return
     if 'APPVEYOR_PULL_REQUEST_NUMBER' in os.environ:
         return

--- a/build.py
+++ b/build.py
@@ -30,10 +30,8 @@ def main():
     # Build package
     pkg_file = conda_build(recipe_dir, args.py_ver)
 
-    # Only upload to Anaconda Cloud when using CI
-    # This check works for most CIs including Travis CI and AppVeyor
-    if os.environ['CI'].lower() == 'true':
-        anaconda_upload(pkg_file, 'yt-project')
+    # Upload package
+    anaconda_upload(pkg_file, 'yt-project')
 
 
 def git_clone(recipe_dir):
@@ -82,6 +80,17 @@ def conda_build(recipe_dir, py_ver):
 
 
 def anaconda_upload(pkg_file, user):
+    # Don't upload when not using CI
+    # This check works for most CIs including Travis CI and AppVeyor
+    if not 'CI' in os.environ:
+        return
+    # Don't upload from pull requests
+    if os.environ['TRAVIS_EVENT_TYPE'] == 'pull_request':
+        return
+    if 'APPVEYOR_PULL_REQUEST_NUMBER' in os.environ:
+        return
+
+    # Now we actually want to upload
     print(f'\nUploading {pkg_file}')
     run([
         'anaconda',

--- a/build.py
+++ b/build.py
@@ -33,8 +33,7 @@ def main():
     # Only upload to Anaconda Cloud when using CI
     # This check works for most CIs including Travis CI and AppVeyor
     if os.environ['CI'].lower() == 'true':
-        # Use my personal account before the official one is set up
-        anaconda_upload(pkg_file, 'qobilidop')
+        anaconda_upload(pkg_file, 'yt-project')
 
 
 def git_clone(recipe_dir):


### PR DESCRIPTION
I was testing on my personal accounts on Travis CI, AppVeyor, and Anaconda Cloud. Now it's time to switch.